### PR TITLE
Fix phi constants

### DIFF
--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -199,7 +199,9 @@ namespace compiler
                     CopyPropagation.Propagate(func.ControlFlowGraph.Root);
                     CopyPropagation.ConstantFolding(func.ControlFlowGraph.Root);
                 }
+
                 CleanUpSsa.Clean(func.ControlFlowGraph.Root);
+
                 //Common Sub Expression Elimination
                 if (Opts.Cse)
                 {

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -199,13 +199,14 @@ namespace compiler
                     CopyPropagation.Propagate(func.ControlFlowGraph.Root);
                     CopyPropagation.ConstantFolding(func.ControlFlowGraph.Root);
                 }
-
+                CleanUpSsa.Clean(func.ControlFlowGraph.Root);
                 //Common Sub Expression Elimination
                 if (Opts.Cse)
                 {
                     CsElimination.Eliminate(func.ControlFlowGraph.Root);
                 }
 
+                
 
                 // Reevaluation
                 if (Opts.DeadCode)

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test007.txt");
+                Compiler.DefaultRun(@"../../testdata/test024.txt");
             }
             catch (ParserException e)
             {

--- a/compiler/compiler.csproj
+++ b/compiler/compiler.csproj
@@ -81,6 +81,7 @@
     <Compile Include="middleend\ir\SsaVariable.cs" />
     <Compile Include="middleend\ir\VariableType.cs" />
     <Compile Include="middleend\ir\WhileNode.cs" />
+    <Compile Include="middleend\optimization\CleanUpSsa.cs" />
     <Compile Include="middleend\optimization\CsElimination.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="frontend\SymbolTable.cs" />

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -942,8 +942,8 @@ namespace compiler.frontend
                 if (falseVar != trueVar.Value)
                 {
                     // This top construction seems to be correct, and should give the best answer, but doesnt
-                    var newInst = new Instruction(IrOps.Phi, trueVar.Value.Value,
-                        falseVar.Value ?? new Operand(falseVar.Location));
+                    var newInst = new Instruction(IrOps.Phi, new Operand(trueVar.Value.Location),
+                        new Operand(falseVar.Location));
 
                     newInst.VArId = trueVar.Value.Identity;
 

--- a/compiler/middleend/optimization/CleanUpSsa.cs
+++ b/compiler/middleend/optimization/CleanUpSsa.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using compiler.middleend.ir;
+
+namespace compiler.middleend.optimization
+{
+    class CleanUpSsa
+    {
+
+        private static HashSet<Node> _visited;
+
+        public static void Clean(Node root)
+        {
+            _visited = new HashSet<Node>();
+            CleanConstSsa(root);
+        }
+
+        private static void CleanConstSsa(Node root)
+        {
+            if ((root == null) || _visited.Contains(root))
+            {
+                return;
+            }
+
+            _visited.Add(root);
+
+            foreach (Instruction instruction in root.Bb.Instructions)
+            {
+                if (instruction.Op == IrOps.Ssa)
+                {
+                    if (instruction.Arg1.Kind == Operand.OpType.Constant)
+                    {
+                        instruction.Op = IrOps.Add;
+                        instruction.Arg2 = new Operand(Operand.OpType.Constant, 0);
+                    }
+                }
+            }
+
+            List<Node> children = root.GetAllChildren();
+
+            foreach (Node child in children)
+            {
+                CleanConstSsa(child);
+            }
+        }
+
+
+
+
+    }
+}

--- a/compiler/middleend/optimization/CsElimination.cs
+++ b/compiler/middleend/optimization/CsElimination.cs
@@ -83,7 +83,7 @@ namespace compiler.middleend.optimization
                         root.Bb.AnchorBlock.InsertKill(bbInstruction.Arg2);
                     }
 
-                    EliminateInternal(root, bbInstruction, removalList, false);
+                    EliminatePriv(root, bbInstruction, removalList, false);
                 }
             }
 
@@ -107,11 +107,11 @@ namespace compiler.middleend.optimization
             // TODO: fix loop cse
             foreach (Instruction instruction in delayed)
             {
-                EliminateInternal(root, instruction, removalList, true);
+                EliminatePriv(root, instruction, removalList, true);
             }
         }
 
-        private static void EliminateInternal(Node root, Instruction bbInstruction, List<Instruction> removalList,
+        private static void EliminatePriv(Node root, Instruction bbInstruction, List<Instruction> removalList,
             bool alternate)
         {
             Instruction predecessor;


### PR DESCRIPTION
Phi instruction operands must be instructions. While it is nice to have constants flow through to their destination, a phi instruction isn't real, and in the end, must just be a register. The value that it represents
must already be present in memory, so we now replace the Ssa instructions with Add instructions if they assign a constant