### PR TITLE
Fix phi constants

### DIFF
--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -258,7 +258,6 @@ namespace compiler
             {
                 parseTree.DominatorTree.IntGraph.Color();
             }
-            //throw new NotImplementedException();
         }
 
 

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -199,7 +199,9 @@ namespace compiler
                     CopyPropagation.Propagate(func.ControlFlowGraph.Root);
                     CopyPropagation.ConstantFolding(func.ControlFlowGraph.Root);
                 }
+
                 CleanUpSsa.Clean(func.ControlFlowGraph.Root);
+
                 //Common Sub Expression Elimination
                 if (Opts.Cse)
                 {

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -199,13 +199,14 @@ namespace compiler
                     CopyPropagation.Propagate(func.ControlFlowGraph.Root);
                     CopyPropagation.ConstantFolding(func.ControlFlowGraph.Root);
                 }
-
+                CleanUpSsa.Clean(func.ControlFlowGraph.Root);
                 //Common Sub Expression Elimination
                 if (Opts.Cse)
                 {
                     CsElimination.Eliminate(func.ControlFlowGraph.Root);
                 }
 
+                
 
                 // Reevaluation
                 if (Opts.DeadCode)

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -92,14 +92,10 @@ namespace compiler
                 file.WriteLine("}");
             }
 
-            using (var file = new StreamWriter(Opts.DomFilename + ".interference"))
-            {
-                //file.WriteLine("digraph Dom{\n");
-                //file.WriteLine(GenInterferenceGraphString());
-                //file.WriteLine("}");
 
-                GenInterferenceGraphString();
-            }
+            // quickgraph makes the files for us, so no using statement here
+            GenInterferenceGraphString();
+            
 
             using (var file = new StreamWriter(Opts.DomFilename + ".code"))
             {

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -213,7 +213,7 @@ namespace compiler
                 // Reevaluation
                 if (Opts.DeadCode)
                 {
-                    throw new NotImplementedException();
+                    DeadCodeElimination.RemoveDeadCode(func.ControlFlowGraph.Root);
                 }
 
                 // Pruning
@@ -302,7 +302,7 @@ namespace compiler
                 GraphOutput = true,
                 CopyProp = true,
                 Cse = true,
-                DeadCode = false,
+                DeadCode = true,
                 PruneCfg = false,
                 RegAlloc = true,
                 InstSched = false,

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -303,7 +303,12 @@ namespace compiler
             }
             GenControlGraphString();
             GenDomGraphString();
+            GenInterferenceGraphString();
+           
+            GenStraightLineFunctions();
             GenInstructionListGraphString();
+            GenDlxGraphString();
+            
         }
 
 

--- a/compiler/Compiler.cs
+++ b/compiler/Compiler.cs
@@ -173,7 +173,6 @@ namespace compiler
             {
                 mystring += parseTree.DominatorTree.PrintInterference() + "\n";
             }
-             
         }
 
         private string GenControlGraphString()
@@ -193,13 +192,13 @@ namespace compiler
             // iterate through each CFG and do the optimizations.
             foreach (ParseTree func in FuncList)
             {
-                bool restart = false;
+                bool restart;
                 do
                 {
-                   restart = TransformIr(func, false);
+                    restart = TransformIr(func, false);
                 } while (restart);
-               
-               
+
+
                 TransformIr(func, true);
 
                 func.ControlFlowGraph.InsertBranches();
@@ -304,11 +303,10 @@ namespace compiler
             GenControlGraphString();
             GenDomGraphString();
             GenInterferenceGraphString();
-           
+
             GenStraightLineFunctions();
             GenInstructionListGraphString();
             GenDlxGraphString();
-            
         }
 
 

--- a/compiler/NUnit.Tests/MiddleEnd/InstructionTests.cs
+++ b/compiler/NUnit.Tests/MiddleEnd/InstructionTests.cs
@@ -101,8 +101,8 @@ namespace NUnit.Tests.MiddleEnd
         [Test]
         public void ToStringTest()
         {
-            Assert.AreEqual(Inst3.Num + ": Bra (" + Inst1.Num + ")", Inst3.ToString().Trim());
-            Assert.AreEqual(Inst2.Num + ": Add #5 (" + Inst1.Num + ")", Inst2.ToString());
+            Assert.AreEqual(Inst3.Num + ": Bra (" + Inst1.Num + ")  : 0", Inst3.ToString().Trim());
+            Assert.AreEqual(Inst2.Num + ": Add #5 (" + Inst1.Num + ") : 0", Inst2.ToString());
         }
     }
 }

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test007.txt");
+                Compiler.DefaultRun(@"../../testdata/test024.txt");
             }
             catch (ParserException e)
             {

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test008.txt");
+                Compiler.DefaultRun(@"../../testdata/test003.txt");
             }
             catch (ParserException e)
             {

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test003.txt");
+                Compiler.DefaultRun(@"../../testdata/cell.txt");
             }
             catch (ParserException e)
             {

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             //try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test002.txt");
+                Compiler.DefaultRun(@"../../testdata/test007.txt");
             }
             //catch (ParserException e)
             {

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -38,15 +38,15 @@ namespace Program
     {
         private static void Main(string[] args)
         {
-            try
+            //try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test024.txt");
+                Compiler.DefaultRun(@"../../testdata/test002.txt");
             }
-            catch (ParserException e)
+            //catch (ParserException e)
             {
-                Console.WriteLine(e.Message);
-                Console.ReadLine();
+                //Console.WriteLine(e.Message);
+              //  Console.ReadLine();
             }
         }
     }

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -38,15 +38,15 @@ namespace Program
     {
         private static void Main(string[] args)
         {
-            //try
+            try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test007.txt");
+                Compiler.DefaultRun(@"../../testdata/test027.txt");
             }
-            //catch (ParserException e)
+            catch (ParserException e)
             {
-                //Console.WriteLine(e.Message);
-              //  Console.ReadLine();
+                Console.WriteLine(e.Message);
+                Console.ReadLine();
             }
         }
     }

--- a/compiler/Program/Program.cs
+++ b/compiler/Program/Program.cs
@@ -41,7 +41,7 @@ namespace Program
             try
             {
                 //TODO: Be sure to address options parsing
-                Compiler.DefaultRun(@"../../testdata/test027.txt");
+                Compiler.DefaultRun(@"../../testdata/test008.txt");
             }
             catch (ParserException e)
             {

--- a/compiler/Program/testdata/test002.txt
+++ b/compiler/Program/testdata/test002.txt
@@ -3,10 +3,16 @@ var x, y, z;
 array [ 4 ] a;
 array [ 4 ][ 4 ] b;
 var c;
+
 function foo( );
 var i, d;
 {
 	let i <- 0;
+	let d <- 0;
+	#let x <- call InputNum();
+	#let y <- call InputNum();
+	#let z <- call InputNum();
+
 	while i < 10 do
 		let y <- y + 2;
 		let z <- x + 2;

--- a/compiler/compiler.csproj
+++ b/compiler/compiler.csproj
@@ -84,6 +84,7 @@
     <Compile Include="middleend\optimization\CleanUpSsa.cs" />
     <Compile Include="middleend\optimization\CsElimination.cs" />
     <Compile Include="middleend\optimization\DeadCodeElimination.cs" />
+    <Compile Include="middleend\optimization\Prune.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="frontend\SymbolTable.cs" />
     <Compile Include="middleend\ir\BasicBlock.cs" />

--- a/compiler/compiler.csproj
+++ b/compiler/compiler.csproj
@@ -83,6 +83,7 @@
     <Compile Include="middleend\ir\WhileNode.cs" />
     <Compile Include="middleend\optimization\CleanUpSsa.cs" />
     <Compile Include="middleend\optimization\CsElimination.cs" />
+    <Compile Include="middleend\optimization\DeadCodeElimination.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="frontend\SymbolTable.cs" />
     <Compile Include="middleend\ir\BasicBlock.cs" />

--- a/compiler/compiler.csproj
+++ b/compiler/compiler.csproj
@@ -81,6 +81,7 @@
     <Compile Include="middleend\ir\SsaVariable.cs" />
     <Compile Include="middleend\ir\VariableType.cs" />
     <Compile Include="middleend\ir\WhileNode.cs" />
+    <Compile Include="middleend\optimization\CleanUpSsa.cs" />
     <Compile Include="middleend\optimization\CsElimination.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="frontend\SymbolTable.cs" />

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -942,8 +942,8 @@ namespace compiler.frontend
                 if (falseVar != trueVar.Value)
                 {
                     // This top construction seems to be correct, and should give the best answer, but doesnt
-                    var newInst = new Instruction(IrOps.Phi, trueVar.Value.Value,
-                        falseVar.Value ?? new Operand(falseVar.Location));
+                    var newInst = new Instruction(IrOps.Phi, new Operand(trueVar.Value.Location),
+                        new Operand(falseVar.Location));
 
                     newInst.VArId = trueVar.Value.Identity;
 

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -28,7 +28,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing;
 using System.Linq;
 using compiler.middleend.ir;
 using VarTbl = System.Collections.Generic.SortedDictionary<int, compiler.middleend.ir.SsaVariable>;

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -540,12 +540,14 @@ namespace compiler.frontend
             return op;
         }
 
+        /*
         public void CreateIdentifier()
         {
             int id = Scanner.Id;
             GetExpected(Token.IDENTIFIER);
             Scanner.SymbolTble.InsertAddress(id, NextAddress());
         }
+        
 
 
         private int NextAddress()
@@ -553,6 +555,7 @@ namespace compiler.frontend
             //TODO: implement this function
             return 0;
         }
+        */
 
         private Operand Num()
         {
@@ -850,7 +853,7 @@ namespace compiler.frontend
             return cfg;
         }
 
-
+        /*
         public void RelOp()
         {
             // TODO implement comparisions (replace IsRelOp)
@@ -863,6 +866,7 @@ namespace compiler.frontend
                 Next();
             }
         }
+        */
 
 
         private ParseResult FuncCall(VarTbl variables)
@@ -1182,7 +1186,7 @@ namespace compiler.frontend
             return false;
         }
 
-
+        /*
         public Tuple<BasicBlock, int> FindInstruction(Instruction inst, Node n)
         {
             if (n == null)
@@ -1202,6 +1206,7 @@ namespace compiler.frontend
 
             return FindInstruction(inst, n.Parent);
         }
+        */
 
 
         private ParseResult ReturnStmt(VarTbl variables)

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -1099,11 +1099,11 @@ namespace compiler.frontend
             last.Child = branchBlock;
             branchBlock.Parent = last;
             branchBlock.Bb.AddInstruction(new Instruction(IrOps.Bra, new Operand(loopHeaderBlock.GetNextInstruction()), null));
-
+            branchBlock.Child = loopHeaderBlock;
             loopBlock.Consolidate();
 
 
-            branchBlock.Child = loopHeaderBlock;
+
             try
             { 
 

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -642,6 +642,7 @@ namespace compiler.frontend
         {
             var cfg = new Cfg {Parameters = new List<VariableType>()};
             cfg.Globals = globals;
+            cfg.UsedGlobals = new List<VariableType>();
 
             FunctionsCfgs.Add(cfg);
 
@@ -758,6 +759,7 @@ namespace compiler.frontend
                         Instruction newInst = new Instruction(IrOps.Store, temp.Value,
                             new Operand(Operand.OpType.Constant, global.Id));
                         epilogue.Bb.AddInstruction(newInst);
+                        cfg.UsedGlobals.Add(global);
                     }
                 }
             }

--- a/compiler/frontend/Parser.cs
+++ b/compiler/frontend/Parser.cs
@@ -445,7 +445,7 @@ namespace compiler.frontend
 
             while ((Tok == Token.VAR) || (Tok == Token.ARRAY))
             {
-                cfg.Globals.AddRange( VarDecl(varTble));
+                cfg.Globals.AddRange(VarDecl(varTble));
             }
 
             while ((Tok == Token.FUNCTION) || (Tok == Token.PROCEDURE))
@@ -665,11 +665,10 @@ namespace compiler.frontend
                 cfg.Parameters = FormalParams(variables);
                 var prologue = new Node(new BasicBlock("Prologue"));
                 cfg.Root = prologue;
-               
+
 
                 if (true)
                 {
-                    
                     foreach (VariableType global in cfg.Globals)
                     {
                         var temp = variables[global.Id];
@@ -677,16 +676,16 @@ namespace compiler.frontend
 
                         if (global.IsArray)
                         {
-                            prologInst = new Instruction(IrOps.Ssa, new Operand(Operand.OpType.Constant, global.Id),null);
+                            prologInst = new Instruction(IrOps.Ssa, new Operand(Operand.OpType.Constant, global.Id),
+                                null);
                         }
                         else
                         {
                             prologInst = new Instruction(IrOps.Load, new Operand(Operand.OpType.Identifier, global.Id),
-                            null);
-
+                                null);
                         }
 
-                        
+
                         cfg.Root.Bb.AddInstruction(prologInst);
                         temp.Value = new Operand(prologInst);
 
@@ -726,7 +725,7 @@ namespace compiler.frontend
                     variables[parameter.Id] = ssa;
                     //arg = new Operand(ssa);
                 }
-                
+
                 //*/
             }
 
@@ -758,7 +757,6 @@ namespace compiler.frontend
                         epilogue.Bb.AddInstruction(newInst);
                     }
                 }
-
             }
 
             cfg.Insert(epilogue);
@@ -966,14 +964,12 @@ namespace compiler.frontend
 
             compBlock.InsertTrue(trueBlock);
             trueBlock.Leaf().InsertJoinTrue(joinBlock);
-            var elseBranch = false;
             if (Tok == Token.ELSE)
             {
                 Next();
                 falseBlock = StatementSequence(ref falseSsa).Root;
                 Node.Leaf(falseBlock).InsertJoinFalse(joinBlock);
                 falseBlock.Consolidate();
-                elseBranch = true;
             }
 
 
@@ -1026,8 +1022,7 @@ namespace compiler.frontend
 
                     if ((newInst.Arg1.Inst == null) || (newInst.Arg2.Inst == null))
                     {
-                        
-                       // throw new ArgumentNullException();
+                        // throw new ArgumentNullException();
                     }
 
                     newInst.VArId = trueVar.Value.Identity;
@@ -1080,32 +1075,30 @@ namespace compiler.frontend
             Node loopBlock = stmts.Root;
 
             Node last = loopBlock.Leaf();
-           
+
 
             // insert the loop body on the true path
             loopHeaderBlock.InsertTrue(loopBlock);
 
-           
 
             GetExpected(Token.OD);
 
             var followBlock = new Node(new BasicBlock("FollowBlock")) {Colorname = "palegreen"};
             var branchBlock = new Node(new BasicBlock("BranchBack"));
             loopHeaderBlock.LoopParent = branchBlock;
-           
+
             loopHeaderBlock.InsertFalse(followBlock);
 
             last.Child = branchBlock;
             branchBlock.Parent = last;
-            branchBlock.Bb.AddInstruction(new Instruction(IrOps.Bra, new Operand(loopHeaderBlock.GetNextInstruction()), null));
+            branchBlock.Bb.AddInstruction(new Instruction(IrOps.Bra, new Operand(loopHeaderBlock.GetNextInstruction()),
+                null));
             branchBlock.Child = loopHeaderBlock;
             loopBlock.Consolidate();
 
 
-
             try
-            { 
-
+            {
                 AddPhiInstructions(variables, loopSsa, headerSsa, loopHeaderBlock, true);
             }
             catch (ArgumentNullException)
@@ -1146,7 +1139,6 @@ namespace compiler.frontend
                         phi.Uses.Add(inst.Arg1);
                         phi.UsesLocations.Add(inst);
                         inst.Arg1 = new Operand(phi);
-
                     }
 
                     if (CheckOperand(inst.Arg2, phi.Arg1) || CheckOperand(inst.Arg2, phi.Arg2))
@@ -1156,7 +1148,6 @@ namespace compiler.frontend
                             phi.Uses.Add(inst.Arg2);
                             phi.UsesLocations.Add(inst);
                             inst.Arg2 = new Operand(phi);
-                            
                         }
                     }
                 }

--- a/compiler/middleend/ir/CFG.cs
+++ b/compiler/middleend/ir/CFG.cs
@@ -46,6 +46,7 @@ namespace compiler.middleend.ir
 
         public List<VariableType> Parameters;
 
+        public List<VariableType> UsedGlobals;
 
         // may not need these
         //public Node Curr { get; set; }

--- a/compiler/middleend/ir/CompareNode.cs
+++ b/compiler/middleend/ir/CompareNode.cs
@@ -91,14 +91,21 @@ namespace compiler.middleend.ir
             cfg.BfsCheckEnqueue(this, FalseNode);
         }
 
-        public override void Consolidate()
+        public override void Consolidate(HashSet<Node> visited)
         {
+            if (visited.Contains(this))
+            {
+                return;
+            }
+
+            visited.Add(this);
+
             CircularRef(Child);
             CircularRef(FalseNode);
 
             // consolidate children who exist
-            Child?.Consolidate();
-            FalseNode?.Consolidate();
+            Child?.Consolidate(visited);
+            FalseNode?.Consolidate(visited);
         }
 
 

--- a/compiler/middleend/ir/CompareNode.cs
+++ b/compiler/middleend/ir/CompareNode.cs
@@ -124,8 +124,11 @@ namespace compiler.middleend.ir
             {
                 // visited.Add(this);
                 Bb.Instructions.Last().Arg2 = new Operand(FalseNode.GetNextInstruction());
-                Join.Parent.Bb.AddInstruction(new Instruction(IrOps.Bra,
-                    new Operand(Join.GetNextInstruction()), null));
+                if (FalseNode != Join)
+                {
+                    Join.Parent.Bb.AddInstruction(new Instruction(IrOps.Bra,
+                        new Operand(Join.GetNextInstruction()), null));
+                }
                 FalseNode.InsertBranches(visited);
                 Child.InsertBranches(visited);
             }

--- a/compiler/middleend/ir/DominatorNode.cs
+++ b/compiler/middleend/ir/DominatorNode.cs
@@ -201,7 +201,7 @@ namespace compiler.middleend.ir
             return local;
         }
 
-
+        /*
         public void Walk(Action<Action<DominatorNode>, DominatorNode> traversal, Action<DominatorNode> visitor)
         {
             traversal(visitor, this);
@@ -226,7 +226,7 @@ namespace compiler.middleend.ir
 
             visitor(n);
         }
-
+        
 
         /// <summary>
         ///     Preorder the specified visitor.
@@ -252,11 +252,11 @@ namespace compiler.middleend.ir
         {
             foreach (DominatorNode child in Children)
             {
-                child.Preorder(visitor);
+                child.Postorder(visitor);
             }
             visitor(this);
         }
-
+        */
 
         /// <summary>
         ///     Dots the identifier.

--- a/compiler/middleend/ir/Instruction.cs
+++ b/compiler/middleend/ir/Instruction.cs
@@ -29,7 +29,7 @@
 using System;
 using System.Collections.Generic;
 using compiler.frontend;
-using compiler.midleend.ir;
+using compiler.middleend.ir;
 
 #endregion
 

--- a/compiler/middleend/ir/Instruction.cs
+++ b/compiler/middleend/ir/Instruction.cs
@@ -226,7 +226,7 @@ namespace compiler.middleend.ir
             string a2 = (Op != IrOps.Bra) && ((Op != IrOps.End) && (Op != IrOps.Load))
                 ? DisplayArg(smb, Arg2)
                 : string.Empty;
-            return $"{Num}: {Op} {a1} {a2} -- Uses {Uses.Count}: {PrintUses(smb)}" ;
+            return $"{Num}: {Op} {a1} {a2} -- Uses {Uses.Count}: {PrintUses(smb)}";
         }
 
 
@@ -235,7 +235,7 @@ namespace compiler.middleend.ir
             var s = string.Empty;
             foreach (Instruction usesLocation in UsesLocations)
             {
-                s += "("+usesLocation.Num + "),";
+                s += "(" + usesLocation.Num + "),";
             }
             return s;
         }
@@ -247,7 +247,7 @@ namespace compiler.middleend.ir
 
         public override string ToString()
         {
-            return "" + Num + ": " + Op + " " + Arg1 + " " + Arg2 + " : "+ Uses.Count;
+            return "" + Num + ": " + Op + " " + Arg1 + " " + Arg2 + " : " + Uses.Count;
         }
 
 

--- a/compiler/middleend/ir/Instruction.cs
+++ b/compiler/middleend/ir/Instruction.cs
@@ -60,6 +60,7 @@ namespace compiler.middleend.ir
                 Next = other.Next;
                 Search = other.Search;
                 Uses = other.Uses;
+                UsesLocations = other.UsesLocations;
             }
         }
 
@@ -81,11 +82,14 @@ namespace compiler.middleend.ir
             Next = null;
             Search = null;
             Uses = new List<Operand>();
+            UsesLocations = new HashSet<Instruction>();
         }
 
         public VariableType VArId { get; set; }
 
         public List<Operand> Uses { get; set; }
+
+        public HashSet<Instruction> UsesLocations { get; set; }
 
         /// <summary>
         ///     The Instruction number
@@ -165,10 +169,12 @@ namespace compiler.middleend.ir
             if (op.Kind == Operand.OpType.Instruction)
             {
                 op.Inst?.Uses.Add(op);
+                op.Inst?.UsesLocations.Add(this);
             }
             else if (op.Kind == Operand.OpType.Variable)
             {
                 op.Variable.Location?.Uses.Add(op);
+                op.Variable.Location?.UsesLocations.Add(this);
             }
         }
 
@@ -220,7 +226,18 @@ namespace compiler.middleend.ir
             string a2 = (Op != IrOps.Bra) && ((Op != IrOps.End) && (Op != IrOps.Load))
                 ? DisplayArg(smb, Arg2)
                 : string.Empty;
-            return $"{Num}: {Op} {a1} {a2}";
+            return $"{Num}: {Op} {a1} {a2} -- Uses {Uses.Count}: {PrintUses(smb)}" ;
+        }
+
+
+        private string PrintUses(SymbolTable smb)
+        {
+            var s = string.Empty;
+            foreach (Instruction usesLocation in UsesLocations)
+            {
+                s += "("+usesLocation.Num + "),";
+            }
+            return s;
         }
 
         private static string DisplayArg(SymbolTable smb, Operand arg)
@@ -230,7 +247,7 @@ namespace compiler.middleend.ir
 
         public override string ToString()
         {
-            return "" + Num + ": " + Op + " " + Arg1 + " " + Arg2;
+            return "" + Num + ": " + Op + " " + Arg1 + " " + Arg2 + " : "+ Uses.Count;
         }
 
 
@@ -239,7 +256,7 @@ namespace compiler.middleend.ir
             foreach (Operand operand in Uses)
             {
                 operand.Inst = newInst;
-                newInst.Uses.Add(new Operand(this));
+                newInst.Uses.Add(operand);
             }
 
             // clear all references just incase we need to fix this in Dead Code Elimination

--- a/compiler/middleend/ir/Instruction.cs
+++ b/compiler/middleend/ir/Instruction.cs
@@ -156,7 +156,10 @@ namespace compiler.middleend.ir
         private void AddRefs()
         {
             AddInstructionRef(Arg1);
-            AddInstructionRef(Arg2);
+            if (Op != IrOps.Store)
+            {
+                AddInstructionRef(Arg2);
+            }
         }
 
         public void AddInstructionRef(Operand op)

--- a/compiler/middleend/ir/InterferenceGraph.cs
+++ b/compiler/middleend/ir/InterferenceGraph.cs
@@ -47,11 +47,11 @@ namespace compiler.middleend.ir
         private UndirectedGraph<Instruction, Edge<Instruction>> _copy =
             new UndirectedGraph<Instruction, Edge<Instruction>>();
 
-        private Stack<Instruction> coloringStack = new Stack<Instruction>();
+        private Stack<Instruction> _coloringStack = new Stack<Instruction>();
 
         // Colored and spilled instructions
         public Dictionary<Instruction, uint> GraphColors = new Dictionary<Instruction, uint>();
-        public uint spillCount = 32; // Virtual register to track spilled instructions, starts at reg 32
+        public uint SpillCount = 32; // Virtual register to track spilled instructions, starts at reg 32
 
         public InterferenceGraph()
         {
@@ -107,7 +107,7 @@ namespace compiler.middleend.ir
                 if (AdjacentDegree(vertex) < RegisterCount)
                 {
                     // Put that node on the coloring stack and remove it from graph
-                    coloringStack.Push(vertex);
+                    _coloringStack.Push(vertex);
                     curGraph.RemoveVertex(vertex);
                     spill = false;
                 }
@@ -119,7 +119,7 @@ namespace compiler.middleend.ir
                 // By default, spills the instruction with the least dependencies
                 // TODO: Maybe come up with a better spilling heuristic
                 var spillVertex = curGraph.Vertices.OrderByDescending(item => AdjacentDegree(item)).Last();
-                GraphColors.Add(spillVertex, spillCount++);
+                GraphColors.Add(spillVertex, SpillCount++);
                 curGraph.RemoveVertex(spillVertex);
             }
 

--- a/compiler/middleend/ir/InterferenceGraph.cs
+++ b/compiler/middleend/ir/InterferenceGraph.cs
@@ -40,10 +40,6 @@ namespace compiler.middleend.ir
 {
     public class InterferenceGraph : UndirectedGraph<Instruction, Edge<Instruction>>
     {
-        public InterferenceGraph()
-        {
-        }
-
         // # of available registers
         private const uint RegisterCount = 27;
 
@@ -51,9 +47,15 @@ namespace compiler.middleend.ir
         private UndirectedGraph<Instruction, Edge<Instruction>> _copy =
             new UndirectedGraph<Instruction, Edge<Instruction>>();
 
+        private Stack<Instruction> coloringStack = new Stack<Instruction>();
+
         // Colored and spilled instructions
         public Dictionary<Instruction, uint> GraphColors = new Dictionary<Instruction, uint>();
         public uint spillCount = 32; // Virtual register to track spilled instructions, starts at reg 32
+
+        public InterferenceGraph()
+        {
+        }
 
         public InterferenceGraph(BasicBlock block)
         {
@@ -73,7 +75,6 @@ namespace compiler.middleend.ir
                 {
                     if (item != null)
                     {
-                       
                         AddVertex(instruction);
                         AddVertex(item);
 
@@ -87,8 +88,6 @@ namespace compiler.middleend.ir
                 }
             }
         }
-
-        private Stack<Instruction> coloringStack = new Stack<Instruction>();
 
         private void ColorRecursive(UndirectedGraph<Instruction, Edge<Instruction>> curGraph)
         {
@@ -111,7 +110,6 @@ namespace compiler.middleend.ir
                     coloringStack.Push(vertex);
                     curGraph.RemoveVertex(vertex);
                     spill = false;
-                    continue;
                 }
             }
 

--- a/compiler/middleend/ir/JoinNode.cs
+++ b/compiler/middleend/ir/JoinNode.cs
@@ -24,7 +24,11 @@
 
 #endregion
 
+#region
+
 using System.Collections.Generic;
+
+#endregion
 
 namespace compiler.middleend.ir
 {
@@ -45,10 +49,12 @@ namespace compiler.middleend.ir
         }
 
 
-        public override void Consolidate(HashSet<Node> visited )
+        public override void Consolidate(HashSet<Node> visited)
         {
             if (visited.Contains(this))
-            { return; }
+            {
+                return;
+            }
             visited.Add(this);
 
             CircularRef(Child);

--- a/compiler/middleend/ir/JoinNode.cs
+++ b/compiler/middleend/ir/JoinNode.cs
@@ -24,6 +24,8 @@
 
 #endregion
 
+using System.Collections.Generic;
+
 namespace compiler.middleend.ir
 {
     public class JoinNode : Node
@@ -43,12 +45,16 @@ namespace compiler.middleend.ir
         }
 
 
-        public override void Consolidate()
+        public override void Consolidate(HashSet<Node> visited )
         {
+            if (visited.Contains(this))
+            { return; }
+            visited.Add(this);
+
             CircularRef(Child);
 
             // consolidate children who exist
-            Child?.Consolidate();
+            Child?.Consolidate(visited);
         }
 
 

--- a/compiler/middleend/ir/Node.cs
+++ b/compiler/middleend/ir/Node.cs
@@ -170,15 +170,17 @@ namespace compiler.middleend.ir
 
         public virtual void Consolidate()
         {
-           HashSet<Node> visited = new HashSet<Node>();
+            HashSet<Node> visited = new HashSet<Node>();
             Consolidate(visited);
         }
 
 
-        public virtual void Consolidate(HashSet<Node> visited )
+        public virtual void Consolidate(HashSet<Node> visited)
         {
-            if(visited.Contains(this))
-            { return;}
+            if (visited.Contains(this))
+            {
+                return;
+            }
 
             visited.Add(this);
 
@@ -204,7 +206,6 @@ namespace compiler.middleend.ir
                 Child.Consolidate(visited);
             }
         }
-
 
 
         public void CircularRef(Node childNode)

--- a/compiler/middleend/ir/Node.cs
+++ b/compiler/middleend/ir/Node.cs
@@ -170,6 +170,18 @@ namespace compiler.middleend.ir
 
         public virtual void Consolidate()
         {
+           HashSet<Node> visited = new HashSet<Node>();
+            Consolidate(visited);
+        }
+
+
+        public virtual void Consolidate(HashSet<Node> visited )
+        {
+            if(visited.Contains(this))
+            { return;}
+
+            visited.Add(this);
+
             if (Child == null)
             {
                 return;
@@ -184,13 +196,15 @@ namespace compiler.middleend.ir
                 Node temp = Child;
                 Child = temp.Child;
 
-                Consolidate();
+                Consolidate(visited);
             }
             else
             {
-                Child.Consolidate();
+                Child.Consolidate(visited);
             }
         }
+
+
 
         public void CircularRef(Node childNode)
         {

--- a/compiler/middleend/ir/Node.cs
+++ b/compiler/middleend/ir/Node.cs
@@ -196,7 +196,8 @@ namespace compiler.middleend.ir
                 Node temp = Child;
                 Child = temp.Child;
 
-                Consolidate(visited);
+                // restart Consolidate from here to coalesc all blocks possible
+                Consolidate();
             }
             else
             {

--- a/compiler/middleend/ir/Register.cs
+++ b/compiler/middleend/ir/Register.cs
@@ -24,7 +24,7 @@
 
 #endregion
 
-namespace compiler.midleend.ir
+namespace compiler.middleend.ir
 {
     public enum Register
     {

--- a/compiler/middleend/ir/WhileNode.cs
+++ b/compiler/middleend/ir/WhileNode.cs
@@ -80,10 +80,12 @@ namespace compiler.middleend.ir
             }
         }
 
-        public override void Consolidate(HashSet<Node> visited )
+        public override void Consolidate(HashSet<Node> visited)
         {
             if (visited.Contains(this))
-            { return;}
+            {
+                return;
+            }
             visited.Add(this);
 
             CircularRef(FalseNode);

--- a/compiler/middleend/ir/WhileNode.cs
+++ b/compiler/middleend/ir/WhileNode.cs
@@ -80,13 +80,17 @@ namespace compiler.middleend.ir
             }
         }
 
-        public override void Consolidate()
+        public override void Consolidate(HashSet<Node> visited )
         {
+            if (visited.Contains(this))
+            { return;}
+            visited.Add(this);
+
             CircularRef(FalseNode);
 
             // consolidate children who exist
-            //Child?.Consolidate();
-            FalseNode?.Consolidate();
+            Child?.Consolidate(visited);
+            FalseNode?.Consolidate(visited);
         }
 
 

--- a/compiler/middleend/optimization/CleanUpSsa.cs
+++ b/compiler/middleend/optimization/CleanUpSsa.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using compiler.middleend.ir;
+
+namespace compiler.middleend.optimization
+{
+    class CleanUpSsa
+    {
+
+        private static HashSet<Node> _visited;
+
+        public static void Clean(Node root)
+        {
+            _visited = new HashSet<Node>();
+            CleanConstSsa(root);
+        }
+
+        private static void CleanConstSsa(Node root)
+        {
+            if ((root == null) || _visited.Contains(root))
+            {
+                return;
+            }
+
+            _visited.Add(root);
+
+            foreach (Instruction instruction in root.Bb.Instructions)
+            {
+                if (instruction.Op == IrOps.Ssa)
+                {
+                    if (instruction.Arg1.Kind == Operand.OpType.Constant)
+                    {
+                        instruction.Op = IrOps.Add;
+                        instruction.Arg2 = new Operand(Operand.OpType.Constant, 0);
+                    }
+                }
+            }
+
+            List<Node> children = root.GetAllChildren();
+
+            foreach (Node child in children)
+            {
+                CleanConstSsa(child);
+            }
+        }
+
+
+
+
+    }
+}

--- a/compiler/middleend/optimization/CleanUpSsa.cs
+++ b/compiler/middleend/optimization/CleanUpSsa.cs
@@ -1,15 +1,40 @@
-﻿using System;
+﻿#region Basic header
+
+// MIT License
+// 
+// Copyright (c) 2016 Paul Kirth
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#endregion
+
+#region
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using compiler.middleend.ir;
+
+#endregion
 
 namespace compiler.middleend.optimization
 {
     class CleanUpSsa
     {
-
         private static HashSet<Node> _visited;
 
         public static void Clean(Node root)
@@ -46,9 +71,5 @@ namespace compiler.middleend.optimization
                 CleanConstSsa(child);
             }
         }
-
-
-
-
     }
 }

--- a/compiler/middleend/optimization/CopyPropagation.cs
+++ b/compiler/middleend/optimization/CopyPropagation.cs
@@ -54,7 +54,7 @@ namespace compiler.middleend.optimization
 
             foreach (Instruction instruction in root.Bb.Instructions)
             {
-                if((instruction.Op == IrOps.Adda) || (instruction.Op == IrOps.Load))
+                if ((instruction.Op == IrOps.Adda) || (instruction.Op == IrOps.Load))
                 {
                     continue;
                 }

--- a/compiler/middleend/optimization/CopyPropagation.cs
+++ b/compiler/middleend/optimization/CopyPropagation.cs
@@ -54,6 +54,12 @@ namespace compiler.middleend.optimization
 
             foreach (Instruction instruction in root.Bb.Instructions)
             {
+                if((instruction.Op == IrOps.Adda) || (instruction.Op == IrOps.Load))
+                {
+                    continue;
+                }
+
+
                 if (instruction.Arg1?.Kind == Operand.OpType.Variable)
                 {
                     instruction.Arg1 = instruction.Arg1.OpenOperand();

--- a/compiler/middleend/optimization/CsElimination.cs
+++ b/compiler/middleend/optimization/CsElimination.cs
@@ -57,7 +57,7 @@ namespace compiler.middleend.optimization
 
             foreach (Instruction bbInstruction in root.Bb.Instructions)
             {
-                if ((bbInstruction.Op != IrOps.Phi) || (bbInstruction.Op == IrOps.Adda))
+                if ((bbInstruction.Op != IrOps.Phi) && (bbInstruction.Op != IrOps.Adda))
                 {
                     if (bbInstruction.Op == IrOps.Load)
                     {
@@ -109,6 +109,9 @@ namespace compiler.middleend.optimization
                     case IrOps.Read:
                     case IrOps.Write:
                     case IrOps.WriteNl:
+                    case IrOps.Adda:
+                    case IrOps.Load:
+
                         break;
                     case IrOps.Neg:
                     case IrOps.Add:
@@ -116,8 +119,8 @@ namespace compiler.middleend.optimization
                     case IrOps.Mul:
                     case IrOps.Div:
                     case IrOps.Cmp:
-                    case IrOps.Adda:
-                    case IrOps.Load:
+                    //case IrOps.Adda:
+                    //case IrOps.Load:
                     default:
                         root.Bb.Instructions.RemoveAll(instruction.ExactMatch);
                         break;

--- a/compiler/middleend/optimization/CsElimination.cs
+++ b/compiler/middleend/optimization/CsElimination.cs
@@ -26,7 +26,6 @@
 
 #region
 
-using System;
 using System.Collections.Generic;
 using compiler.middleend.ir;
 

--- a/compiler/middleend/optimization/CsElimination.cs
+++ b/compiler/middleend/optimization/CsElimination.cs
@@ -26,6 +26,7 @@
 
 #region
 
+using System;
 using System.Collections.Generic;
 using compiler.middleend.ir;
 
@@ -91,7 +92,36 @@ namespace compiler.middleend.optimization
             foreach (Instruction instruction in removalList)
             {
                 //root.Bb.AnchorBlock.FindOpChain(instruction.Op).RemoveAll(instruction.ExactMatch);
-                root.Bb.Instructions.RemoveAll(instruction.ExactMatch);
+                switch (instruction.Op)
+                {
+                    case IrOps.Store:
+                    case IrOps.Move:
+                    case IrOps.Phi:
+                    case IrOps.End:
+                    case IrOps.Bra:
+                    case IrOps.Bne:
+                    case IrOps.Beq:
+                    case IrOps.Ble:
+                    case IrOps.Blt:
+                    case IrOps.Bge:
+                    case IrOps.Bgt:
+                    case IrOps.Ret:
+                    case IrOps.Read:
+                    case IrOps.Write:
+                    case IrOps.WriteNl:
+                        break;
+                    case IrOps.Neg:
+                    case IrOps.Add:
+                    case IrOps.Sub:
+                    case IrOps.Mul:
+                    case IrOps.Div:
+                    case IrOps.Cmp:
+                    case IrOps.Adda:
+                    case IrOps.Load:
+                    default:
+                        root.Bb.Instructions.RemoveAll(instruction.ExactMatch);
+                        break;
+                }
 
                 //rely on using instruction hashkey for removing a particular instruction
                 //root.Bb.Graph.RemoveVertex(instruction);

--- a/compiler/middleend/optimization/CsElimination.cs
+++ b/compiler/middleend/optimization/CsElimination.cs
@@ -83,7 +83,7 @@ namespace compiler.middleend.optimization
                         root.Bb.AnchorBlock.InsertKill(bbInstruction.Arg2);
                     }
 
-                    EliminateInternal(root, bbInstruction, removalList, false);
+                    EliminatePriv(root, bbInstruction, removalList, false);
                 }
             }
 
@@ -107,11 +107,11 @@ namespace compiler.middleend.optimization
             // TODO: fix loop cse
             foreach (Instruction instruction in delayed)
             {
-                EliminateInternal(root, instruction, removalList, true);
+                EliminatePriv(root, instruction, removalList, true);
             }
         }
 
-        private static void EliminateInternal(Node root, Instruction bbInstruction, List<Instruction> removalList,
+        private static void EliminatePriv(Node root, Instruction bbInstruction, List<Instruction> removalList,
             bool alternate)
         {
             Instruction predecessor;

--- a/compiler/middleend/optimization/DeadCodeElimination.cs
+++ b/compiler/middleend/optimization/DeadCodeElimination.cs
@@ -1,15 +1,40 @@
-﻿using System;
+﻿#region Basic header
+
+// MIT License
+// 
+// Copyright (c) 2016 Paul Kirth
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#endregion
+
+#region
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using compiler.middleend.ir;
+
+#endregion
 
 namespace compiler.middleend.optimization
 {
     class DeadCodeElimination
     {
-
         private static HashSet<Node> _visited;
 
         public static void RemoveDeadCode(Node root)
@@ -62,7 +87,6 @@ namespace compiler.middleend.optimization
                             removalList.Add(instruction);
                         }
                         break;
-
                 }
             }
 
@@ -78,6 +102,5 @@ namespace compiler.middleend.optimization
                 RemoveDead(child);
             }
         }
-
     }
 }

--- a/compiler/middleend/optimization/DeadCodeElimination.cs
+++ b/compiler/middleend/optimization/DeadCodeElimination.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using compiler.middleend.ir;
+
+namespace compiler.middleend.optimization
+{
+    class DeadCodeElimination
+    {
+
+        private static HashSet<Node> _visited;
+
+        public static void RemoveDeadCode(Node root)
+        {
+            _visited = new HashSet<Node>();
+            RemoveDead(root);
+        }
+
+        private static void RemoveDead(Node root)
+        {
+            if ((root == null) || _visited.Contains(root))
+            {
+                return;
+            }
+
+            _visited.Add(root);
+
+            List<Instruction> removalList = new List<Instruction>();
+            foreach (Instruction instruction in root.Bb.Instructions)
+            {
+                switch (instruction.Op)
+                {
+                    case IrOps.Store:
+                    case IrOps.Move:
+                    case IrOps.Phi:
+                    case IrOps.End:
+                    case IrOps.Bra:
+                    case IrOps.Bne:
+                    case IrOps.Beq:
+                    case IrOps.Ble:
+                    case IrOps.Blt:
+                    case IrOps.Bge:
+                    case IrOps.Bgt:
+                    case IrOps.Ret:
+                    case IrOps.Read:
+                    case IrOps.Write:
+                    case IrOps.WriteNl:
+                        break;
+                    case IrOps.Neg:
+                    case IrOps.Add:
+                    case IrOps.Sub:
+                    case IrOps.Mul:
+                    case IrOps.Div:
+                    case IrOps.Cmp:
+                    case IrOps.Adda:
+                    case IrOps.Load:
+                    default:
+                        if (instruction.Uses.Count == 0)
+                        {
+                            removalList.Add(instruction);
+                        }
+                        break;
+
+                }
+            }
+
+            foreach (Instruction instruction in removalList)
+            {
+                root.Bb.Instructions.Remove(instruction);
+            }
+
+            List<Node> children = root.GetAllChildren();
+
+            foreach (Node child in children)
+            {
+                RemoveDead(child);
+            }
+        }
+
+    }
+}

--- a/compiler/middleend/optimization/LiveRanges.cs
+++ b/compiler/middleend/optimization/LiveRanges.cs
@@ -28,7 +28,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization.Formatters;
 using compiler.middleend.ir;
 
 #endregion

--- a/compiler/middleend/optimization/LiveRanges.cs
+++ b/compiler/middleend/optimization/LiveRanges.cs
@@ -32,7 +32,7 @@ using compiler.middleend.ir;
 
 #endregion
 
-namespace compiler
+namespace compiler.middleend.optimization
 {
     public class LiveRanges
     {

--- a/compiler/middleend/optimization/LiveRanges.cs
+++ b/compiler/middleend/optimization/LiveRanges.cs
@@ -79,7 +79,7 @@ namespace compiler
 
         private static void AddArgToLiveRange(Operand arg, HashSet<Instruction> live)
         {
-            if ((arg?.Kind == Operand.OpType.Instruction) && (arg.Inst.Op != IrOps.Ssa))
+            if ((arg?.Kind == Operand.OpType.Instruction) && (arg.Inst?.Op != IrOps.Ssa))
             {
                 live.Add(arg.Inst);
             }

--- a/compiler/middleend/optimization/Prune.cs
+++ b/compiler/middleend/optimization/Prune.cs
@@ -1,9 +1,37 @@
-﻿using System;
+﻿#region Basic header
+
+// MIT License
+// 
+// Copyright (c) 2016 Paul Kirth
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#endregion
+
+#region
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using compiler.middleend.ir;
+
+#endregion
 
 namespace compiler.middleend.optimization
 {
@@ -30,11 +58,11 @@ namespace compiler.middleend.optimization
 
             if (root.GetType() == typeof(CompareNode))
             {
-               
                 var instList = root.Bb.Instructions;
                 Instruction cmp = instList.Find((current) => current.Op == IrOps.Cmp);
 
-                if ((cmp?.Arg1.OpenOperand().Kind == Operand.OpType.Constant) && (cmp?.Arg2.OpenOperand().Kind == Operand.OpType.Constant))
+                if ((cmp?.Arg1.OpenOperand().Kind == Operand.OpType.Constant) &&
+                    (cmp?.Arg2.OpenOperand().Kind == Operand.OpType.Constant))
                 {
                     var branch = instList.Last();
                     bool takeBranch;
@@ -66,7 +94,7 @@ namespace compiler.middleend.optimization
                             throw new Exception("Comparison cannot be evaluated!");
                     }
 
-                    CompareNode compareNode = (CompareNode)root;
+                    CompareNode compareNode = (CompareNode) root;
                     Node begin = compareNode.Parent;
                     JoinNode join = compareNode.Join;
                     Node joinParent = takeBranch ? join.FalseParent : join.Parent;
@@ -79,7 +107,6 @@ namespace compiler.middleend.optimization
                         if (takeBranch)
                         {
                             bbInstruction.ReplaceInst(bbInstruction.Arg2.Inst);
-                            
                         }
                         else
                         {
@@ -92,7 +119,6 @@ namespace compiler.middleend.optimization
                     // only required to check if the evaluation is always false
                     if (takeBranch && (compareNode.Join == compareNode.FalseNode))
                     {
-                        
                         begin.Child = end;
                         end.Parent = begin;
                     }
@@ -108,24 +134,22 @@ namespace compiler.middleend.optimization
 
                     //compareNode.Parent = null;
 
-                    
+
                     //begin.Consolidate();
 
                     PruneBranches(begin.Child);
                     return true;
                 }
-
             }
 
             List<Node> children = root.GetAllChildren();
 
             foreach (Node child in children)
             {
-               mutatedGraph  = (mutatedGraph || PruneBranches(child));
+                mutatedGraph = (mutatedGraph || PruneBranches(child));
             }
 
             return mutatedGraph;
         }
-
     }
 }

--- a/compiler/middleend/optimization/Prune.cs
+++ b/compiler/middleend/optimization/Prune.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using compiler.middleend.ir;
+
+namespace compiler.middleend.optimization
+{
+    class Prune
+    {
+        private static HashSet<Node> _visited;
+
+        public static bool StartPrune(Node root)
+        {
+            _visited = new HashSet<Node>();
+            return PruneBranches(root);
+        }
+
+        private static bool PruneBranches(Node root)
+        {
+            if ((root == null) || _visited.Contains(root))
+            {
+                return false;
+            }
+
+            _visited.Add(root);
+
+            bool mutatedGraph = false;
+
+            if (root.GetType() == typeof(CompareNode))
+            {
+               
+                var instList = root.Bb.Instructions;
+                Instruction cmp = instList.Find((current) => current.Op == IrOps.Cmp);
+
+                if ((cmp?.Arg1.OpenOperand().Kind == Operand.OpType.Constant) && (cmp?.Arg2.OpenOperand().Kind == Operand.OpType.Constant))
+                {
+                    var branch = instList.Last();
+                    bool takeBranch;
+                    switch (branch.Op)
+                    {
+                        case IrOps.Bne:
+                            takeBranch = cmp.Arg1.Val != cmp.Arg2.Val;
+                            break;
+                        case IrOps.Beq:
+                            takeBranch = cmp.Arg1.Val == cmp.Arg2.Val;
+                            break;
+                        case IrOps.Ble:
+                            takeBranch = cmp.Arg1.Val <= cmp.Arg2.Val;
+                            break;
+                        case IrOps.Blt:
+                            takeBranch = cmp.Arg1.Val < cmp.Arg2.Val;
+                            break;
+                        case IrOps.Bge:
+                            takeBranch = cmp.Arg1.OpenOperand().Val >= cmp.Arg2.OpenOperand().Val;
+                            break;
+                        case IrOps.Bgt:
+                            takeBranch = cmp.Arg1.Val > cmp.Arg2.Val;
+                            break;
+                        default:
+                            throw new Exception("Comparison cannot be evaluated!");
+                    }
+
+                    CompareNode compareNode = (CompareNode)root;
+                    Node begin = compareNode.Parent;
+                    JoinNode join = compareNode.Join;
+                    Node joinParent = takeBranch ? join.FalseParent : join.Parent;
+                    Node end = join.Child;
+                    Node keep = takeBranch ? compareNode.FalseNode : compareNode.Child;
+
+                    // propagate phi results
+                    foreach (Instruction bbInstruction in join.Bb.Instructions)
+                    {
+                        if (takeBranch)
+                        {
+                            bbInstruction.ReplaceInst(bbInstruction.Arg2.Inst);
+                            
+                        }
+                        else
+                        {
+                            bbInstruction.ReplaceInst(bbInstruction.Arg1.Inst);
+                        }
+                    }
+
+
+                    // check to see if we have a real else branch or a regular if
+                    // only required to check if the evaluation is always false
+                    if (takeBranch && (compareNode.Join == compareNode.FalseNode))
+                    {
+                        
+                        begin.Child = end;
+                        end.Parent = begin;
+                    }
+                    else
+                    {
+                        // move nodes around
+                        begin.Child = keep;
+                        keep.Parent = begin;
+
+                        joinParent.Child = end;
+                        end.Parent = joinParent;
+                    }
+
+                    //compareNode.Parent = null;
+
+                    
+                    //begin.Consolidate();
+
+                    PruneBranches(begin.Child);
+                    return true;
+                }
+
+            }
+
+            List<Node> children = root.GetAllChildren();
+
+            foreach (Node child in children)
+            {
+               mutatedGraph  = (mutatedGraph || PruneBranches(child));
+            }
+
+            return mutatedGraph;
+        }
+
+    }
+}

--- a/compiler/middleend/optimization/Prune.cs
+++ b/compiler/middleend/optimization/Prune.cs
@@ -38,25 +38,29 @@ namespace compiler.middleend.optimization
                 {
                     var branch = instList.Last();
                     bool takeBranch;
+
+                    var arg1 = cmp.Arg1.OpenOperand().Val;
+                    var arg2 = cmp.Arg2.OpenOperand().Val;
+
                     switch (branch.Op)
                     {
                         case IrOps.Bne:
-                            takeBranch = cmp.Arg1.Val != cmp.Arg2.Val;
+                            takeBranch = arg1 != arg2;
                             break;
                         case IrOps.Beq:
-                            takeBranch = cmp.Arg1.Val == cmp.Arg2.Val;
+                            takeBranch = arg1 == arg2;
                             break;
                         case IrOps.Ble:
-                            takeBranch = cmp.Arg1.Val <= cmp.Arg2.Val;
+                            takeBranch = arg1 <= arg2;
                             break;
                         case IrOps.Blt:
-                            takeBranch = cmp.Arg1.Val < cmp.Arg2.Val;
+                            takeBranch = arg1 < arg2;
                             break;
                         case IrOps.Bge:
-                            takeBranch = cmp.Arg1.OpenOperand().Val >= cmp.Arg2.OpenOperand().Val;
+                            takeBranch = arg1 >= arg2;
                             break;
                         case IrOps.Bgt:
-                            takeBranch = cmp.Arg1.Val > cmp.Arg2.Val;
+                            takeBranch = arg1 > arg2;
                             break;
                         default:
                             throw new Exception("Comparison cannot be evaluated!");

--- a/compiler/middleend/optimization/Prune.cs
+++ b/compiler/middleend/optimization/Prune.cs
@@ -62,7 +62,7 @@ namespace compiler.middleend.optimization
                 Instruction cmp = instList.Find((current) => current.Op == IrOps.Cmp);
 
                 if ((cmp?.Arg1.OpenOperand().Kind == Operand.OpType.Constant) &&
-                    (cmp?.Arg2.OpenOperand().Kind == Operand.OpType.Constant))
+                    (cmp.Arg2.OpenOperand().Kind == Operand.OpType.Constant))
                 {
                     var branch = instList.Last();
                     bool takeBranch;


### PR DESCRIPTION
This is a fairly large PR. There are a few new files and a lot of clean up done to support the new optimization passes.

Began adding support for global variables to  support the changes to the phi instructions

Fixed phi instructions to never hold constants by replacing with add instructions after initial optimizations had completed. 

Added Prune to reconfigure the CFG when we can evaluate a compare block due to copy propagation or CSE. 

Added many misc. items to fix bugs, and support debugging
